### PR TITLE
Fix tracker bar not loading music roll when inserted via automation

### DIFF
--- a/src/main/java/com/finchy/pipeorgans/content/midi/trackerBar/TrackerBarBlockEntity.java
+++ b/src/main/java/com/finchy/pipeorgans/content/midi/trackerBar/TrackerBarBlockEntity.java
@@ -57,6 +57,9 @@ public class TrackerBarBlockEntity extends KineticBlockEntity implements MenuPro
         @Override
         protected void onContentsChanged(int slot) {
             super.onContentsChanged(slot);
+            if (be.level != null && !be.level.isClientSide && be.midiSequencerBehaviour != null) {
+                be.onRollChanged();
+            }
             be.setChanged();
         }
     }
@@ -128,12 +131,19 @@ public class TrackerBarBlockEntity extends KineticBlockEntity implements MenuPro
     protected void write(CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
         super.write(tag, registries, clientPacket);
         tag.put("Inventory", inventory.serializeNBT(registries));
+        tag.putBoolean("ButtonsEnabled", buttonsEnabled);
     }
 
     @Override
     protected void read(CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
         super.read(tag, registries, clientPacket);
         inventory.deserializeNBT(registries, tag.getCompound("Inventory"));
+        if (tag.contains("ButtonsEnabled")) {
+            buttonsEnabled = tag.getBoolean("ButtonsEnabled");
+        }
+        if (level != null && !level.isClientSide && midiSequencerBehaviour != null) {
+            onRollChanged();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

Fixes #96

When a music roll is inserted into a tracker bar through automation (hopper/funnel), the sequencer never loads the song and the GUI buttons stay greyed out because \onContentsChanged()\ did not trigger \onRollChanged()\.

### Changes

1. **TrackerBarInventory.onContentsChanged**: Now calls \be.onRollChanged()\ when the inventory changes on the server side
2. **write()**: Now persists \buttonsEnabled\ in NBT so it survives chunk reloads
3. **read()**: Now restores \buttonsEnabled\ from NBT and reloads the roll via \onRollChanged()\ when the block entity is read

These are the same changes I described in the issue.