### PR TITLE
Bug fix: Redstone and Note links popping off pipes with pipe swaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ mcmodsrepo
 
 # Files from Forge MDK
 forge*changelog.txt
+
+# Mac Garbage
+.DS_Store

--- a/src/main/java/com/finchy/pipeorgans/content/pipes/generic/GenericPipeBlock.java
+++ b/src/main/java/com/finchy/pipeorgans/content/pipes/generic/GenericPipeBlock.java
@@ -182,7 +182,6 @@ public abstract class GenericPipeBlock extends Block implements PipeBehaviour, I
         Direction facing = state.getValue(FACING);
         boolean wall = state.getValue(WALL);
         boolean powered = state.getValue(POWERED);
-        level.destroyBlock(pos, false);
 
         GenericPipeBlock pipe = (GenericPipeBlock) ((GenericPipeBlockItem) heldItem.getItem()).getBlock();
 


### PR DESCRIPTION
Swapping a pipe (right-clicking with a different pipe) causes any attached Note and Redstone Link blocks to be destroyed. This fixes it by replacing the pipe in place instead of momentarily destroying it.

**To reproduce:**
1. Place pipe on appropriate block
2. Attach Note Link or Redstone Link to base of pipe
3. Right click the pipe with a different type of pipe
4. Attached link pops off and drops the items

**Cause**
GenericPipeBlock.placeNewPipe removes the old pipe by replacing it with air, destroying all attached blocks. By the time the new pipe is swapped in, the links are gone.

**Fix**
Remove the destroyBlock, and the air phase is never reached. This is safe because:
- setBlock to a different block naturally removes the old block entity
- The old pipe is returned to the player

**Scope**
This only works for links attached to the pipe base. Links attached to the pipe further up still are destroyed. But the pipe base is what matters as that is what receives the redstone signal.

**Testing**
Swapped pipes with redstone and note links in creative and survival, and observed preservation of items and intended behavior.