### PR TITLE
Feature: Raise simultaneous sound-channel limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ mcmodsrepo
 
 # Files from Forge MDK
 forge*changelog.txt
+
+# Mac Garbage
+.DS_Store

--- a/src/main/java/com/finchy/pipeorgans/ClientConfig.java
+++ b/src/main/java/com/finchy/pipeorgans/ClientConfig.java
@@ -36,7 +36,7 @@ public class ClientConfig {
             .defineInRange("sounds.pipeFadeSpeed", 0.25d, 0.01d, 0.5d);
 
     public static final ForgeConfigSpec.IntValue MAX_SOUND_SOURCES = BUILDER
-            .comment("Max simultaneous sound channels. Raises Minecraft's 255 cap so large organs don't cut out.", "Requires a restart. Higher values use more RAM/CPU.")
+            .comment("Max simultaneous sound channels.", "Higher values use more RAM/CPU. Restart to apply.")
             .defineInRange("sounds.maxSoundSources", 512, 256, 2048);
 
     //Clipboard Assisted Placement Config (CAP)

--- a/src/main/java/com/finchy/pipeorgans/ClientConfig.java
+++ b/src/main/java/com/finchy/pipeorgans/ClientConfig.java
@@ -35,6 +35,9 @@ public class ClientConfig {
             .comment("How fast pipe sounds fade out per tick (higher = faster)")
             .defineInRange("sounds.pipeFadeSpeed", 0.25d, 0.01d, 0.5d);
 
+    public static final ForgeConfigSpec.IntValue MAX_SOUND_SOURCES = BUILDER
+            .comment("Max simultaneous sound channels. Raises Minecraft's 255 cap so large organs don't cut out.", "Requires a restart. Higher values use more RAM/CPU.")
+            .defineInRange("sounds.maxSoundSources", 512, 256, 2048);
 
     //Clipboard Assisted Placement Config (CAP)
     public static final ForgeConfigSpec.BooleanValue CAP_ENABLED = BUILDER
@@ -56,6 +59,7 @@ public class ClientConfig {
     public static double whistleChiffVolume;
     public static double pipeAttenuationDistance;
     public static double pipeFadeSpeed;
+    public static int maxSoundSources;
     public static boolean capEnabled;
     public static CAPDirection capDefaultDirection;
     public static boolean capCopyMode;
@@ -67,6 +71,7 @@ public class ClientConfig {
         whistleChiffVolume = WHISTLE_CHIFF_VOLUME.get();
         pipeAttenuationDistance = PIPE_ATTENUATION_DISTANCE.get();
         pipeFadeSpeed = PIPE_FADE_SPEED.get();
+        maxSoundSources = MAX_SOUND_SOURCES.get();
         capEnabled = CAP_ENABLED.get();
         capDefaultDirection = CAP_DEFAULT_DIRECTION.get();
         capCopyMode = CAP_COPY_MODE.get();

--- a/src/main/java/com/finchy/pipeorgans/mixin/SoundLibraryMixin.java
+++ b/src/main/java/com/finchy/pipeorgans/mixin/SoundLibraryMixin.java
@@ -9,8 +9,10 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.nio.IntBuffer;
 
@@ -28,22 +30,22 @@ public class SoundLibraryMixin {
         }
     }
 
-    // Dynamically tests the hardware limit starting from the requested config limit downwards.
     @Redirect(method = "init(Ljava/lang/String;Z)V", at = @At(value = "INVOKE", target = "Lorg/lwjgl/openal/ALC10;alcCreateContext(JLjava/nio/IntBuffer;)J"))
     private long pipeorgans$createContextWithMaxSupportedSources(long device, IntBuffer ignoredNull) {
         int requestedMono = pipeorgans$maxSources();
         long context = 0;
 
-        // Loop downwards until the OS accepts the channel weight.
-        // Decrementing by blocks of 32 preserves optimal memory alignment for OpenAL Soft.
+        // Steps down from config maximum in aligned blocks until OS accepts the stream weight
         while (requestedMono >= 64) {
             try (MemoryStack stack = MemoryStack.stackPush()) {
-                IntBuffer attrs = stack.mallocInt(5)
-                        .put(ALC11.ALC_MONO_SOURCES).put(requestedMono)
-                        .put(ALC11.ALC_STEREO_SOURCES).put(16)
-                        .put(0);
-                attrs.flip();
+                // Ensure exact 4-byte boundaries, stopping pitch & pan distortion
+                int[] attribArray = new int[] {
+                    ALC11.ALC_MONO_SOURCES, requestedMono,
+                    ALC11.ALC_STEREO_SOURCES, 16,
+                    0
+                };
 
+                IntBuffer attrs = stack.ints(attribArray);
                 context = ALC10.alcCreateContext(device, attrs);
 
                 if (context != 0) {

--- a/src/main/java/com/finchy/pipeorgans/mixin/SoundLibraryMixin.java
+++ b/src/main/java/com/finchy/pipeorgans/mixin/SoundLibraryMixin.java
@@ -6,6 +6,7 @@ import org.lwjgl.openal.ALC10;
 import org.lwjgl.openal.ALC11;
 import org.lwjgl.system.MemoryStack;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
@@ -15,6 +16,10 @@ import java.nio.IntBuffer;
 
 @Mixin(Library.class)
 public class SoundLibraryMixin {
+
+    @Unique
+    private static int pipeorgans$allocatedMaxSources = 255;
+
     private static int pipeorgans$maxSources() {
         try {
             return ClientConfig.MAX_SOUND_SOURCES.get();
@@ -23,23 +28,43 @@ public class SoundLibraryMixin {
         }
     }
 
-    // Ask OpenAL for more mono sources instead of accepting the ~256 default.
+    // Dynamically tests the hardware limit starting from the requested config limit downwards.
     @Redirect(method = "init(Ljava/lang/String;Z)V", at = @At(value = "INVOKE", target = "Lorg/lwjgl/openal/ALC10;alcCreateContext(JLjava/nio/IntBuffer;)J"))
-    private long pipeorgans$createContextWithMoreSources(long device, IntBuffer ignoredNull) {
-        int mono = pipeorgans$maxSources();
-        try (MemoryStack stack = MemoryStack.stackPush()) {
-            IntBuffer attrs = stack.mallocInt(5)
-                    .put(ALC11.ALC_MONO_SOURCES).put(mono)
-                    .put(ALC11.ALC_STEREO_SOURCES).put(16)
-                    .put(0);
-            attrs.flip();
-            return ALC10.alcCreateContext(device, attrs);
+    private long pipeorgans$createContextWithMaxSupportedSources(long device, IntBuffer ignoredNull) {
+        int requestedMono = pipeorgans$maxSources();
+        long context = 0;
+
+        // Loop downwards until the OS accepts the channel weight.
+        // Decrementing by blocks of 32 preserves optimal memory alignment for OpenAL Soft.
+        while (requestedMono >= 64) {
+            try (MemoryStack stack = MemoryStack.stackPush()) {
+                IntBuffer attrs = stack.mallocInt(5)
+                        .put(ALC11.ALC_MONO_SOURCES).put(requestedMono)
+                        .put(ALC11.ALC_STEREO_SOURCES).put(16)
+                        .put(0);
+                attrs.flip();
+
+                context = ALC10.alcCreateContext(device, attrs);
+
+                if (context != 0) {
+                    pipeorgans$allocatedMaxSources = requestedMono;
+                    break;
+                }
+            }
+            requestedMono -= 32;
         }
+
+        // Fallback
+        if (context == 0) {
+            context = ALC10.alcCreateContext(device, (IntBuffer) null);
+            pipeorgans$allocatedMaxSources = 255;
+        }
+
+        return context;
     }
 
-    // Lift the hard 255 cap on the static channel pool to the configured maximum.
     @ModifyConstant(method = "init(Ljava/lang/String;Z)V", constant = @Constant(intValue = 255))
-    private int pipeorgans$raiseStaticCap(int original) {
-        return pipeorgans$maxSources();
+    private int pipeorgans$raiseStaticCapToTrueAllocated(int original) {
+        return pipeorgans$allocatedMaxSources;
     }
 }

--- a/src/main/java/com/finchy/pipeorgans/mixin/SoundLibraryMixin.java
+++ b/src/main/java/com/finchy/pipeorgans/mixin/SoundLibraryMixin.java
@@ -1,0 +1,45 @@
+package com.finchy.pipeorgans.mixin;
+
+import com.finchy.pipeorgans.ClientConfig;
+import com.mojang.blaze3d.audio.Library;
+import org.lwjgl.openal.ALC10;
+import org.lwjgl.openal.ALC11;
+import org.lwjgl.system.MemoryStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.nio.IntBuffer;
+
+@Mixin(Library.class)
+public class SoundLibraryMixin {
+    private static int pipeorgans$maxSources() {
+        try {
+            return ClientConfig.MAX_SOUND_SOURCES.get();
+        } catch (IllegalStateException notLoadedYet) {
+            return 512;
+        }
+    }
+
+    // Ask OpenAL for more mono sources instead of accepting the ~256 default.
+    @Redirect(method = "init(Ljava/lang/String;Z)V", at = @At(value = "INVOKE", target = "Lorg/lwjgl/openal/ALC10;alcCreateContext(JLjava/nio/IntBuffer;)J"))
+    private long pipeorgans$createContextWithMoreSources(long device, IntBuffer ignoredNull) {
+        int mono = pipeorgans$maxSources();
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            IntBuffer attrs = stack.mallocInt(5)
+                    .put(ALC11.ALC_MONO_SOURCES).put(mono)
+                    .put(ALC11.ALC_STEREO_SOURCES).put(16)
+                    .put(0);
+            attrs.flip();
+            return ALC10.alcCreateContext(device, attrs);
+        }
+    }
+
+    // Lift the hard 255 cap on the static channel pool to the configured maximum.
+    @ModifyConstant(method = "init(Ljava/lang/String;Z)V", constant = @Constant(intValue = 255))
+    private int pipeorgans$raiseStaticCap(int original) {
+        return pipeorgans$maxSources();
+    }
+}

--- a/src/main/resources/pipeorgans.mixins.json
+++ b/src/main/resources/pipeorgans.mixins.json
@@ -11,7 +11,8 @@
     "FanUpdateWindchestMixin",
     "RedstoneLinkNetworkHandlerMixin",
     "WhistleBlockMixin",
-    "WhistleBlockEntityMixin"
+    "WhistleBlockEntityMixin",
+    "SoundLibraryMixin"
   ],
   "mixinextras": {
     "minVersion": "0.5.0"

--- a/src/main/resources/pipeorgans.mixins.json
+++ b/src/main/resources/pipeorgans.mixins.json
@@ -11,7 +11,9 @@
     "FanUpdateWindchestMixin",
     "RedstoneLinkNetworkHandlerMixin",
     "WhistleBlockMixin",
-    "WhistleBlockEntityMixin",
+    "WhistleBlockEntityMixin"
+  ],
+  "client": [
     "SoundLibraryMixin"
   ],
   "mixinextras": {


### PR DESCRIPTION
Large organs play many looping pipe sounds at once and can easily hit Minecraft's hard cap of ~255 simultaneous positional sounds, causing pipes to drop out or go silent. This feature adds a configurable maximum (default 512) by requesting more sources from OpenAL at context creation and lifting the engine's static-channel cap to match.
  
**Problem**
Each sounding pipe holds one looping GenericSoundInstance = one OpenAL source. On a large organ the number of concurrent sources exceeds Minecraft's limit and sounds get cut off.
  
**Root cause**
In com.mojang.blaze3d.audio.Library.init (1.20.1):
 ```
this.context = ALC10.alcCreateContext(this.currentDevice, (IntBuffer) null);
int i = this.getChannelCount(); 
ALC_MONO_SOURCES; ~256 by default
int streaming = Mth.clamp(Mth.sqrt(i), 2, 8);
int static_   = Mth.clamp(i - streaming, 8, 255);
```
The context is created with null attributes, so OpenAL Soft hands out its default (~256) mono sources, and the static pool is then clamped to 255. Faking a larger getChannelCount() does not help as OpenAL still only allocates ~256 real sources, so anything beyond that fails.
  
**Fix**
A client-only mixin into Library.init:

1. Redirects the alcCreateContext call to pass ALC_MONO_SOURCES = maxSoundSources (plus a small stereo request), so OpenAL actually allocates the sources. This also makes getChannelCount() naturally return the higher value.
2. @ModifyConstant raises the 255 static-pool cap to maxSoundSources.

Both values come from a single config option, so they stay in sync.
  
**Files changed**
  - ClientConfig.java: new MAX_SOUND_SOURCES option (sounds.maxSoundSources, default 512, range 256–2048), plus its runtime field and syncFromFile() wiring.
  - mixin/SoundLibraryMixin.java: new client mixin, reads the config defensively with a 512 fallback in case audio init runs before config load.
  - pipeorgans.mixins.json: register SoundLibraryMixin under a new client block
  
**Notes**
  - Requires a restart. The OpenAL context is created once at startup.
  - Cross-platform: Minecraft/LWJGL bundles OpenAL Soft on Windows/macOS/Linux (x86-64 and ARM) and mixes sources in software, so this behaves identically on all OSes and isn't bound by hardware voices.
  - Default kept modest (512) so normal players don't observe high CPU/RAM rates for sources they won't use.
  - Client-only
  
**Testing**
  - Ensured the f3 menu 'sounds' denominator was above 255
  - Built a large contraption that produced over 255 sounds, and made sure that over 255 were triggered (in f3).