### PR TITLE
Bug fix: Orphaned Network Transmitters

### DIFF
--- a/src/generated/resources/.cache/1fcf2bb79b724d153939f414684b24d2c9e34c17
+++ b/src/generated/resources/.cache/1fcf2bb79b724d153939f414684b24d2c9e34c17
@@ -1,4 +1,4 @@
-// 1.20.1	2026-02-16T09:14:03.8368327	Create: Sound of Steam's Advancements
+// 1.20.1	2026-06-30T20:08:39.272665	Create: Sound of Steam's Advancements
 3bc36bfbed7e42b66def87948512222fbe81e8d1 data/pipeorgans/advancements/bassoon.json
 c4a2999883d3a28be0c3c797ea75d7a37c70173b data/pipeorgans/advancements/brass_reed.json
 4c3df3ac380332d74b6fcd68e74b73e1fc5e3ce9 data/pipeorgans/advancements/chamade.json
@@ -18,7 +18,7 @@ cf72e422ea82871bbd733a0b79a939e491071065 data/pipeorgans/advancements/posaune.js
 1592efeb37b7788b7524dd22845f576047d00a6b data/pipeorgans/advancements/rohrflote.json
 8f7190cde4d17baafc924d35a85b17544242579a data/pipeorgans/advancements/root.json
 96383e86167e4e71d0875cff9822ba9e99872d07 data/pipeorgans/advancements/steam_base.json
-9cad07320e73fcb5b7a4053a80fc8d5b2542b51f data/pipeorgans/advancements/subbass.json
+9623dac8fcdaf93ba4eb3c8f5b6a24b7b8d7ce7b data/pipeorgans/advancements/subbass.json
 717cd4679881e7782df0001e19c10a7b65c0c8a8 data/pipeorgans/advancements/tierce.json
 391368e74bd9205ca4bf1b96c09c9840acbc82c6 data/pipeorgans/advancements/trompette.json
 05478f75e16a54690ba573ec85c22dbd11940e69 data/pipeorgans/advancements/viola.json

--- a/src/generated/resources/.cache/daa6a61776a9803765d6dc203baa6f596c5b41ca
+++ b/src/generated/resources/.cache/daa6a61776a9803765d6dc203baa6f596c5b41ca
@@ -1,4 +1,4 @@
-// 1.20.1	2026-06-03T21:07:32.5515419	Registrate Provider for pipeorgans [Recipes, Advancements, Loot Tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
+// 1.20.1	2026-06-30T20:08:39.274668	Registrate Provider for pipeorgans [Recipes, Advancements, Loot Tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
 8e39d8877707a62ab2683b5612b9a85b020e09bf assets/pipeorgans/blockstates/base.json
 c746142a5971f7d9610400061ae6db7288f39cc5 assets/pipeorgans/blockstates/bassoon.json
 0f7ac7604f0fee26a230e70f6419cb10df907237 assets/pipeorgans/blockstates/bassoon_extension.json
@@ -48,15 +48,15 @@ ad18c8d11c01f8d723d551cf7370a0951b487c9f assets/pipeorgans/blockstates/vox_human
 a474fdb57fa8df1514d2f542958d9d5a18a4e638 assets/pipeorgans/blockstates/vox_humana_extension.json
 e2a66bfca8771ebaf42a85daf74ee2eac92cc060 assets/pipeorgans/blockstates/windchest.json
 7d2b2a163210c68e8cae4dfaa23748404230334b assets/pipeorgans/blockstates/windchest_master.json
-be31c7a009d90aa25d998b6ae386eaa616a633fd assets/pipeorgans/lang/en_ud.json
-38e7eb5a552b44127d67150e13e3df21dd9fdaf7 assets/pipeorgans/lang/en_us.json
+26a60a2a69a24816dcb353e6d1e54c2b781a6e14 assets/pipeorgans/lang/en_ud.json
+4569c404f8d200894456f7dfb2786188b91a92b7 assets/pipeorgans/lang/en_us.json
 c5f754282449380c27e6b04ae291520a0b061373 assets/pipeorgans/models/block/base/base_floor_powered.json
 a7d69e8a06fc232cbc074e3ea3a52c228d55b27a assets/pipeorgans/models/block/base/base_wall_powered.json
 6377819f02fb199c0ae28c0e0aac4cafbf2e2ce3 assets/pipeorgans/models/item/base.json
 5222fb9af26819181080d3972452098f486e4e5d assets/pipeorgans/models/item/bassoon.json
-2302273fb8ea11e0f175b8f3341100b33c11a066 assets/pipeorgans/models/item/brassbound_boot.json
 063bd5c9267543e9220cd28ec3ea7afd5c857bf2 assets/pipeorgans/models/item/brass_boot.json
 38f339f412a9597e5809f1563743ee5c3fa1c5bc assets/pipeorgans/models/item/brass_reed.json
+2302273fb8ea11e0f175b8f3341100b33c11a066 assets/pipeorgans/models/item/brassbound_boot.json
 9382b2e5ba262b49eaeeefac252b1140663c8a06 assets/pipeorgans/models/item/chamade.json
 80e0dff1f182dfe9dec7e6e0bb413033c98ac007 assets/pipeorgans/models/item/copper_boot.json
 3767fb51a4305f5398947499b68b1901e0090c8d assets/pipeorgans/models/item/dark_oak_boot.json

--- a/src/generated/resources/assets/pipeorgans/lang/en_ud.json
+++ b/src/generated/resources/assets/pipeorgans/lang/en_ud.json
@@ -331,7 +331,7 @@
   "pipeorgans.ponder.pipe_swapping.header": "sǝdıd ʇuǝɹǝɟɟıp buıddɐʍS",
   "pipeorgans.ponder.pipe_swapping.text_1": "ʇı uo ɯǝʇı s,ǝdıԀ ɹǝɥʇouɐ buısn ʎq ǝdıԀ ɐ ɟo ǝdʎʇ ǝɥʇ ǝbuɐɥɔ ʎןʇuɐʇsuı uɐɔ noʎ",
   "pipeorgans.ponder.pipe_swapping.text_2": "ʎɐʍ ǝɥʇ uı ʇǝb uɐɔ sʞɔoןq 'buoן ooʇ sı ǝdıd ʍǝu ǝɥʇ ɟı 'ɹǝʌǝʍoH",
-  "pipeorgans.ponder.pipe_swapping.text_3": "˙ʎɐʍ ǝɥʇ uı ǝɹɐ ʇɐɥʇ sʞɔoןq ʎuɐ ǝʌoɯǝɹ ʎןdɯıs 'sıɥʇ xıɟ o⟘",
+  "pipeorgans.ponder.pipe_swapping.text_3": "ʎɐʍ ǝɥʇ uı ǝɹɐ ʇɐɥʇ sʞɔoןq ʎuɐ ǝʌoɯǝɹ ʎןdɯıs 'sıɥʇ xıɟ o⟘",
   "pipeorgans.ponder.pipe_swapping.text_4": "sǝdıd ןɐʇuozıɹoɥ ɹoɟ sǝob ǝɯɐs ǝɥ⟘",
   "pipeorgans.ponder.tracker_bar.header": "sןןoɹ ɔısnɯ buıʎɐןԀ",
   "pipeorgans.ponder.tracker_bar.text_1": "sןןoɹ ɔısnɯ ɯoɹɟ sǝןıɟ IᗡIW ʎɐןd oʇ pǝsn sı ɹɐᗺ ɹǝʞɔɐɹ⟘ ǝɥ⟘",

--- a/src/generated/resources/assets/pipeorgans/lang/en_us.json
+++ b/src/generated/resources/assets/pipeorgans/lang/en_us.json
@@ -331,7 +331,7 @@
   "pipeorgans.ponder.pipe_swapping.header": "Swapping different pipes",
   "pipeorgans.ponder.pipe_swapping.text_1": "You can instantly change the type of a Pipe by using another Pipe's item on it",
   "pipeorgans.ponder.pipe_swapping.text_2": "However, if the new pipe is too long, blocks can get in the way",
-  "pipeorgans.ponder.pipe_swapping.text_3": "To fix this, simply remove any blocks that are in the way.",
+  "pipeorgans.ponder.pipe_swapping.text_3": "To fix this, simply remove any blocks that are in the way",
   "pipeorgans.ponder.pipe_swapping.text_4": "The same goes for horizontal pipes",
   "pipeorgans.ponder.tracker_bar.header": "Playing music rolls",
   "pipeorgans.ponder.tracker_bar.text_1": "The Tracker Bar is used to play MIDI files from music rolls",

--- a/src/generated/resources/data/pipeorgans/advancements/subbass.json
+++ b/src/generated/resources/data/pipeorgans/advancements/subbass.json
@@ -5,7 +5,7 @@
       "conditions": {
         "location": [
           {
-            "block": "pipeorgans:rohrflote",
+            "block": "pipeorgans:subbass",
             "condition": "minecraft:block_state_property"
           }
         ]

--- a/src/main/java/com/finchy/pipeorgans/content/midi/RedstoneMidiTransmitter.java
+++ b/src/main/java/com/finchy/pipeorgans/content/midi/RedstoneMidiTransmitter.java
@@ -91,20 +91,17 @@ public class RedstoneMidiTransmitter {
     }
 
     public void changeFrequencyKey(int channel, ItemStack newKey) {
+        FrequencyKeys.set(channel, Frequency.of(newKey));
         for (Map.Entry<Integer, ManualNoteFrequency> entry : activeNotes.get(channel).entrySet()) {
             ManualNoteFrequency oldNote = entry.getValue();
-
-            if (oldNote.getSecond().getFirst().getStack().equals(newKey)) // if the new key is the same as the existing key
-                return;
+            if (oldNote.getSecond().getFirst().getStack().equals(newKey))
+                continue; // frequency unchanged for this note, skip
             Create.REDSTONE_LINK_NETWORK_HANDLER.removeFromNetwork(be.getLevel(), oldNote);
-
             Frequency pitchFreq = oldNote.getSecond().getSecond();
             ManualNoteFrequency newNoteFrequency = ManualNoteFrequency.create(oldNote.pos, Frequency.of(newKey), pitchFreq, oldNote.strength);
             entry.setValue(newNoteFrequency);
             Create.REDSTONE_LINK_NETWORK_HANDLER.addToNetwork(be.getLevel(), newNoteFrequency);
         }
-        FrequencyKeys.set(channel, Frequency.of(newKey));
-
     }
 
     public void stopAllNotes() {
@@ -124,9 +121,14 @@ public class RedstoneMidiTransmitter {
     }
 
     public void activateNote(int channel, int pitch, int velocity) {
+        Map<Integer, ManualNoteFrequency> channelNotes = activeNotes.get(channel);
+        // Remove any existing transmitter for this pitch before adding a new one
+        ManualNoteFrequency existing = channelNotes.get(pitch);
+        if (existing != null)
+            Create.REDSTONE_LINK_NETWORK_HANDLER.removeFromNetwork(be.getLevel(), existing);
         ManualNoteFrequency noteFrequency = noteFrequency(channel, pitch, velocity);
         Create.REDSTONE_LINK_NETWORK_HANDLER.addToNetwork(be.getLevel(), noteFrequency);
-        activeNotes.get(channel).put(pitch, noteFrequency);
+        channelNotes.put(pitch, noteFrequency);
     }
 
     public void deactivateNote(int channel, int pitch) {


### PR DESCRIPTION
**Context**
With Create's Redstone Links, every transmitter and receiver must be explicitly registered and deregistered.  If it is never deregistered, the object stays in the handler's internal data structures indefinitely, making it exempt from garbage collection and can greatly affect performance given prolonged use of MIDI functions.
    
**Bug**
In activateNote:
 ``` 
  public void activateNote(int channel, int pitch, int velocity) {
      ManualNoteFrequency noteFrequency = noteFrequency(channel, pitch,
  velocity);
      Create.REDSTONE_LINK_NETWORK_HANDLER.addToNetwork(be.getLevel(),
  noteFrequency);
      activeNotes.get(channel).put(pitch, noteFrequency);
  }
  ```
activeNotes is a map of channel to (pitch to ManualNoteFrequency). The put call returns and discards the previous value if one already exists for that pitch. No removeFromNetwork is ever called on it.
  
This means if activateNote is called for a (channel, pitch) that already has an active note, the sequence replays without cleanup, and remains registered in Create's network handler. From that point on there is no reference to it anywhere in this codebase. The only code paths that deregister a ManualNoteFrequency are deactivateNote, stopAllNotes, and changeFrequencyKey, all of which look up notes by pitch from activeNotes, which no longer contains the orphaned object.
  
The orphaned transmitter is now permanently stuck in Create's network. It reports getTransmittedStrength() of whatever velocity the note had forever. The note signal never turns off for receivers on that frequency. And the object itself cannot be garbage collected as long as the network handler holds it.
  
**How the bug affects performance**
Every duplicate note-on adds another orphan. In a session with active MIDI playback, this can accumulate into dozens or hundreds of stuck transmitters, each holding memory and potentially emitting ghost signals on the redstone link network. I experienced notable performance drops with increased MIDI playback (which would be solved by a relog), this fix addresses.

**The Fix**
Check for and remove any existing transmitter before registering a new one. This guarantees there is at most one registered transmitter per (channel, pitch) at any time, and that the old one is always properly deregistered before being replaced.