### PR TITLE
Bug fix: Keyboard relay becoming permanently unusable after logout (#81, #98) [NEEDS TESTING]

### DIFF
--- a/src/main/java/com/finchy/pipeorgans/content/midi/keyboardRelay/KeyboardRelayBlockEntity.java
+++ b/src/main/java/com/finchy/pipeorgans/content/midi/keyboardRelay/KeyboardRelayBlockEntity.java
@@ -46,15 +46,12 @@ public class KeyboardRelayBlockEntity extends SmartBlockEntity implements MenuPr
     }
 
     public void onBlockRemoved() {
-        Entity playerEntity = ((ServerLevel)this.level).getEntity(this.user);
-        if (playerEntity instanceof Player player) {
-            if (isUsedBy(player)) {
-                user = null;
-                if (player != null) {
-                    player.getPersistentData().remove("UsingKBRelayPos");
-                    midiSourceBehaviour.link.stopAllNotes();
-                }
-            }
+        midiSourceBehaviour.link.stopAllNotes();
+        if (user != null) {
+            Entity playerEntity = ((ServerLevel) this.level).getEntity(this.user);
+            if (playerEntity instanceof Player player)
+                player.getPersistentData().remove("UsingKBRelayPos");
+            user = null;
         }
     }
 
@@ -81,6 +78,18 @@ public class KeyboardRelayBlockEntity extends SmartBlockEntity implements MenuPr
     }
 
     public void tryStartUsing(Player player) {
+        // Clear stale persistent data if the stored position no longer points to a KBR that knows this player
+        if (playerIsUsing(player)) {
+            BlockPos storedPos = playerUsingKBRPos(player);
+            boolean stale = storedPos == null;
+            if (!stale) {
+                if (!(level.getBlockEntity(storedPos) instanceof KeyboardRelayBlockEntity otherKbr)
+                        || !otherKbr.isUsedBy(player))
+                    stale = true;
+            }
+            if (stale)
+                player.getPersistentData().remove("UsingKBRelayPos");
+        }
         if (!deactivatedThisTick && !hasUser() && !playerIsUsing(player) && playerInRange(player, level, worldPosition)) {
             startUsing(player);
         }


### PR DESCRIPTION
Closes Issues #81 #98 

**Disclaimer**
I am away from my MIDI keyboard for the next week, so an unable to verify that these changes work. But hypothetically they _SHOULD_ fix the reported issues. Please test before merging, and request further modifications if it doesn't work.

**Bug**
When a player was actively using a keyboard relay and closed the world or disconnected from a server, stopUsing() was never called, leaving UsingKBRelayPos permanently set in the player's persistent NBT data. On the next login, playerIsUsing() returned true and tryStartUsing() refused to activate, locking them out forever until they died or manually edited their NBT.
  
**Fix**
Adds a stale-data check at the top of tryStartUsing(): if UsingKBRelayPos is set but the block at that position is no longer a keyboard relay with this player registered as its user, the entry is cleared before proceeding. This resolves itself on the first interaction after updating; no world edit or death required. onBlockRemoved() is also fixed to unconditionally stop all notes and clear the user, rather than only doing so if the player happened to be online at the time of removal.